### PR TITLE
Implemented pre-processor directives in the source code to remove the…

### DIFF
--- a/Radiation_Model/source/OpticallyThick/RadiativeRates.h
+++ b/Radiation_Model/source/OpticallyThick/RadiativeRates.h
@@ -4,7 +4,7 @@
 // *
 // * (c) Dr. Stephen J. Bradshaw
 // *
-// * Date last modified: 03/19/2018
+// * Date last modified: 06/06/2018
 // *
 // ****
 
@@ -14,7 +14,8 @@
 #ifdef NLTE_CHROMOSPHERE
 
 #define MAX_ITERATIONS			300
-#define CONVERGENCE_EPSILON		0.1
+// #define CONVERGENCE_EPSILON		0.10		// Original
+#define CONVERGENCE_EPSILON		0.25
 #define CONVERGENCE_CONDITION		1E-6
 
 

--- a/Radiation_Model/source/radiation.cpp
+++ b/Radiation_Model/source/radiation.cpp
@@ -4,7 +4,7 @@
 // *
 // * (c) Dr. Stephen J. Bradshaw
 // *
-// * Date last modified: 11/16/2017
+// * Date last modified: 06/06/2018
 // *
 // ****
 
@@ -22,12 +22,46 @@
 
 CRadiation::CRadiation( char *szFilename )
 {
-Initialise( szFilename );
+#if !defined (USE_POWER_LAW_RADIATIVE_LOSSES)
+	// The power-law radiative losses ARE NOT being used
+	// The atomic data are required to calculate the radiative losses
+	Initialise( szFilename );
+#else // !(USE_POWER_LAW_RADIATIVE_LOSSES)
+	// The power-law radiative losses ARE being used
+	#ifdef OPTICALLY_THICK_RADIATION
+		#if defined (NLTE_CHROMOSPHERE) || defined(DECOUPLE_IONISATION_STATE_SOLVER)
+			// If the NLTE chromosphere is being used or a non-equilibrium ionization calculation is being performed then the atomic data are required
+			Initialise( szFilename );
+		#endif // NLTE_CHROMOSPHERE || DECOUPLE_IONISATION_STATE_SOLVER
+	#else // OPTICALLY_THICK_RADIATION
+		#ifdef DECOUPLE_IONISATION_STATE_SOLVER
+			// If a non-equilibrium ionisation calculation is being performed then the atomic data are required
+			Initialise( szFilename );
+		#endif // DECOUPLE_IONISATION_STATE_SOLVER
+	#endif // OPTICALLY_THICK_RADIATION
+#endif // !(USE_POWER_LAW_RADIATIVE_LOSSES)
 }
 
 CRadiation::~CRadiation( void )
 {
-FreeAll();
+#if !defined (USE_POWER_LAW_RADIATIVE_LOSSES)
+	// The power-law radiative losses ARE NOT being used
+	// The atomic data are required to calculate the radiative losses
+	FreeAll();
+#else // !(USE_POWER_LAW_RADIATIVE_LOSSES)
+	// The power-law radiative losses ARE being used
+	#ifdef OPTICALLY_THICK_RADIATION
+		#if defined (NLTE_CHROMOSPHERE) || defined(DECOUPLE_IONISATION_STATE_SOLVER)
+			// If the NLTE chromosphere is being used or a non-equilibrium ionization calculation is being performed then the atomic data are required
+			FreeAll();
+		#endif // NLTE_CHROMOSPHERE || DECOUPLE_IONISATION_STATE_SOLVER
+	#else // OPTICALLY_THICK_RADIATION
+		#ifdef DECOUPLE_IONISATION_STATE_SOLVER
+			// If a non-equilibrium ionisation calculation is being performed then the atomic data are required
+			FreeAll();
+		#endif // DECOUPLE_IONISATION_STATE_SOLVER
+	#endif // OPTICALLY_THICK_RADIATION
+#endif // !(USE_POWER_LAW_RADIATIVE_LOSSES)
 }
 
 void CRadiation::Initialise( char *szFilename )


### PR DESCRIPTION
… need to load atomic data into memory when only power-law radiative losses are used in the radiation calculation. Also weakened the convergence criterion for the hydrogen model solver based on findings from NRL testing.