### PR TITLE
Remove need to have atomic data when using power-law losses

### DIFF
--- a/Radiation_Model/source/radiation.cpp
+++ b/Radiation_Model/source/radiation.cpp
@@ -21,12 +21,46 @@
 
 CRadiation::CRadiation( char *szFilename )
 {
-Initialise( szFilename );
+#if !defined (USE_POWER_LAW_RADIATIVE_LOSSES)
+	// The power-law radiative losses ARE NOT being used
+	// The atomic data are required to calculate the radiative losses
+	Initialise( szFilename );
+#else // !(USE_POWER_LAW_RADIATIVE_LOSSES)
+	// The power-law radiative losses ARE being used
+	#ifdef OPTICALLY_THICK_RADIATION
+		#if defined (NLTE_CHROMOSPHERE) || defined(DECOUPLE_IONISATION_STATE_SOLVER)
+			// If the NLTE chromosphere is being used or a non-equilibrium ionization calculation is being performed then the atomic data are required
+			Initialise( szFilename );
+		#endif // NLTE_CHROMOSPHERE || DECOUPLE_IONISATION_STATE_SOLVER
+	#else // OPTICALLY_THICK_RADIATION
+		#ifdef DECOUPLE_IONISATION_STATE_SOLVER
+			// If a non-equilibrium ionisation calculation is being performed then the atomic data are required
+			Initialise( szFilename );
+		#endif // DECOUPLE_IONISATION_STATE_SOLVER
+	#endif // OPTICALLY_THICK_RADIATION
+#endif // !(USE_POWER_LAW_RADIATIVE_LOSSES)
 }
 
 CRadiation::~CRadiation( void )
 {
-FreeAll();
+#if !defined (USE_POWER_LAW_RADIATIVE_LOSSES)
+	// The power-law radiative losses ARE NOT being used
+	// The atomic data are required to calculate the radiative losses
+	FreeAll();
+#else // !(USE_POWER_LAW_RADIATIVE_LOSSES)
+	// The power-law radiative losses ARE being used
+	#ifdef OPTICALLY_THICK_RADIATION
+		#if defined (NLTE_CHROMOSPHERE) || defined(DECOUPLE_IONISATION_STATE_SOLVER)
+			// If the NLTE chromosphere is being used or a non-equilibrium ionization calculation is being performed then the atomic data are required
+			FreeAll();
+		#endif // NLTE_CHROMOSPHERE || DECOUPLE_IONISATION_STATE_SOLVER
+	#else // OPTICALLY_THICK_RADIATION
+		#ifdef DECOUPLE_IONISATION_STATE_SOLVER
+			// If a non-equilibrium ionisation calculation is being performed then the atomic data are required
+			FreeAll();
+		#endif // DECOUPLE_IONISATION_STATE_SOLVER
+	#endif // OPTICALLY_THICK_RADIATION
+#endif // !(USE_POWER_LAW_RADIATIVE_LOSSES)
 }
 
 void CRadiation::Initialise( char *szFilename )


### PR DESCRIPTION
This PR adds back in commits from #18 that were overridden in a subsequent PR.