### PR TITLE
Add checks for OS and compiler for importing alloca.h

### DIFF
--- a/Radiation_Model/source/OpticallyThick/RadiativeRates.cpp
+++ b/Radiation_Model/source/OpticallyThick/RadiativeRates.cpp
@@ -18,8 +18,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <alloca.h>
 #include <math.h>
+
+// alloca() is a non-standard function, so the header that contains
+// it depends on the operating system and compiler.  The following
+// should catch the major cases (Unix, Mac, Cygwin, MinGW, MSVC).
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
+  // MSVC or MinGW
+  #include <malloc.h>
+#elif defined(__unix__) || defined(__APPLE__) || defined(__CYGWIN__)
+  // Linux, macOS, or Cygwin
+  #include <alloca.h>
+#else
+  #error "Error in RadiativeRates.cpp: alloca not supported on this platform."
+#endif
 
 #include "../../../Resources/source/fitpoly.h"
 #include "../../../Resources/source/file.h"


### PR DESCRIPTION
This checks the OS and compiler for importing alloca.h in RadiativeRates.cpp.  Since it's non-standard, the `alloca()` function can be found in different headers on different OSes.

~~I haven't tested on all the different OSes just yet, so just a draft PR for the moment.~~